### PR TITLE
Adding casts to allow c_char being u8

### DIFF
--- a/src/static_lib.rs
+++ b/src/static_lib.rs
@@ -2227,7 +2227,7 @@ impl FrameBuffer {
     /// Will be passed to `bgfx::CallbackI::screenShot` callback.
     pub fn request_screen_shot(&self, file_path: &i8) {
         unsafe {
-            bgfx_sys::bgfx_request_screen_shot(self.handle, file_path);
+            bgfx_sys::bgfx_request_screen_shot(self.handle, file_path as *const i8 as *const ::std::os::raw::c_char);
         }
     }
 }
@@ -3184,7 +3184,7 @@ impl Encoder {
     pub fn set_marker(&self, marker: &i8) {
         unsafe {
             let _self = std::mem::transmute(self);
-            bgfx_sys::bgfx_encoder_set_marker(_self, marker);
+            bgfx_sys::bgfx_encoder_set_marker(_self, marker as *const i8 as *const ::std::os::raw::c_char);
         }
     }
     /// * `state`:
@@ -5085,7 +5085,7 @@ pub fn encoder_end(encoder: &Encoder) {
 /// Will be passed to `bgfx::CallbackI::screenShot` callback.
 pub fn request_screen_shot(handle: &FrameBuffer, file_path: &i8) {
     unsafe {
-        bgfx_sys::bgfx_request_screen_shot(handle.handle, file_path);
+        bgfx_sys::bgfx_request_screen_shot(handle.handle, file_path as *const i8 as *const ::std::os::raw::c_char);
     }
 }
 /// * `msecs`:
@@ -5114,7 +5114,7 @@ pub fn get_internal_data() -> &'static InternalData {
 /// Marker string.
 pub fn set_marker(marker: &i8) {
     unsafe {
-        bgfx_sys::bgfx_set_marker(marker);
+        bgfx_sys::bgfx_set_marker(marker as *const i8 as *const ::std::os::raw::c_char);
     }
 }
 /// * `state`:


### PR DESCRIPTION
On certain platforms `std::os::raw::c_char `will equal to `u8` instead of `i8` leading to compilation errors in bgfx-rs/src/static_lib.rs. i.e. compiling for
- aarch64
- arm
- powerpc
- powerpc64

https://github.com/rust-lang/rust/blob/3af60f831f75ae2632bbfd4c1aa66049ec2d486a/src/libstd/os/raw.rs#L15-L28

Compilation output before the proposed changes:
```
   Compiling bgfx-rs v0.9.0
error[E0308]: mismatched types
    --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bgfx-rs-0.9.0/src/static_lib.rs:2230:61
     |
2230 |             bgfx_sys::bgfx_request_screen_shot(self.handle, file_path);
     |                                                             ^^^^^^^^^ expected `u8`, found `i8`
     |
     = note: expected raw pointer `*const u8`
                  found reference `&i8`

error[E0308]: mismatched types
    --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bgfx-rs-0.9.0/src/static_lib.rs:3187:54
     |
3187 |             bgfx_sys::bgfx_encoder_set_marker(_self, marker);
     |                                                      ^^^^^^ expected `u8`, found `i8`
     |
     = note: expected raw pointer `*const u8`
                  found reference `&i8`

error[E0308]: mismatched types
    --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bgfx-rs-0.9.0/src/static_lib.rs:5088:59
     |
5088 |         bgfx_sys::bgfx_request_screen_shot(handle.handle, file_path);
     |                                                           ^^^^^^^^^ expected `u8`, found `i8`
     |
     = note: expected raw pointer `*const u8`
                  found reference `&i8`

error[E0308]: mismatched types
    --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bgfx-rs-0.9.0/src/static_lib.rs:5117:35
     |
5117 |         bgfx_sys::bgfx_set_marker(marker);
     |                                   ^^^^^^ expected `u8`, found `i8`
     |
     = note: expected raw pointer `*const u8`
                  found reference `&i8`

```

After these changes compilation is successful (tested using armv7-linux-androideabi, aarch64-linux-android, i686-linux-android, x86_64-linux-android).