### PR TITLE
Fix web example

### DIFF
--- a/web_example/src/main.rs
+++ b/web_example/src/main.rs
@@ -189,6 +189,9 @@ fn main() -> std::io::Result<()> {
 
     let shader_program = create_shader_program()?;
 
+    bgfx::reset(WIDTH as _, HEIGHT as _, ResetArgs::default());
+    bgfx::set_view_rect(0, 0, 0, WIDTH as _, HEIGHT as _);
+
     let state = Box::new(State {
         vbh,
         ibh,

--- a/web_example/src/main.rs
+++ b/web_example/src/main.rs
@@ -16,6 +16,7 @@ struct PosColorVertex {
 }
 
 static CANVAS_ID: &[u8; 7] = b"canvas\0";
+
 static VS_CUBES: &[u8] =
     include_bytes!("../../resources/examples/runtime/shaders/essl/vs_cubes.bin");
 static FS_CUBES: &[u8] =
@@ -166,20 +167,6 @@ fn main() -> std::io::Result<()> {
             ..Default::default()
         },
     );
-
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
-    glfw.window_hint(glfw::WindowHint::ClientApi(glfw::ClientApiHint::NoApi));
-
-    let (mut window, _events) = glfw
-        .create_window(
-            WIDTH as _,
-            HEIGHT as _,
-            "cubes.rs bgfx-sys example - ESC to close",
-            glfw::WindowMode::Windowed,
-        )
-        .expect("Failed to create GLFW window.");
-
-    window.set_key_polling(true);
 
     let layout = VertexLayoutBuilder::begin(RendererType::Noop)
         .add(Attrib::Position, 3, AttribType::Float, AddArgs::default())


### PR DESCRIPTION
[Fix duplicated GLFW window creation.](https://github.com/emoon/bgfx-rs/commit/250aeb261cbe38c9de16fde8aa1c44d0d8adc71b)

This was preventing the web context from being created due to an internal GLFW check preventing duplicate window creation.

[Properly reset the viewport to avoid squished viewport.](https://github.com/emoon/bgfx-rs/commit/3a5a71d9ef2325518a5e07d1411ffa0affef6011)

This copies the lines from bgfx-sys which is doing this and looks ok out of the box.

**Before:**

![image](https://github.com/emoon/bgfx-rs/assets/602268/181bdb99-aec1-456c-96ea-e3877ba8feb9)

**After:**

![image](https://github.com/emoon/bgfx-rs/assets/602268/da8ad83a-b008-4a47-81b7-b99b9e1d6fe8)



